### PR TITLE
update Okabe-Ito URL to wayback machine link

### DIFF
--- a/R/palettes.R
+++ b/R/palettes.R
@@ -1,7 +1,7 @@
 
 #' Color palette proposed by Okabe and Ito
 #'
-#' Two color palettes taken from the article "Color Universal Design" by Okabe and Ito, http://jfly.iam.u-tokyo.ac.jp/color/.
+#' Two color palettes taken from the article ["Color Universal Design" by Okabe and Ito](https://web.archive.org/web/20210108233739/http://jfly.iam.u-tokyo.ac.jp/color/).
 #' The variant `palette_OkabeIto` contains a gray color, while `palette_OkabeIto_black` contains black instead.
 #' @export
 palette_OkabeIto <- c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7", "#999999")

--- a/man/palette_OkabeIto.Rd
+++ b/man/palette_OkabeIto.Rd
@@ -5,14 +5,18 @@
 \alias{palette_OkabeIto}
 \alias{palette_OkabeIto_black}
 \title{Color palette proposed by Okabe and Ito}
-\format{An object of class \code{character} of length 8.}
+\format{
+An object of class \code{character} of length 8.
+
+An object of class \code{character} of length 8.
+}
 \usage{
 palette_OkabeIto
 
 palette_OkabeIto_black
 }
 \description{
-Two color palettes taken from the article "Color Universal Design" by Okabe and Ito, http://jfly.iam.u-tokyo.ac.jp/color/.
+Two color palettes taken from the article \href{https://web.archive.org/web/20210108233739/http://jfly.iam.u-tokyo.ac.jp/color/}{"Color Universal Design" by Okabe and Ito}.
 The variant \code{palette_OkabeIto} contains a gray color, while \code{palette_OkabeIto_black} contains black instead.
 }
 \keyword{datasets}


### PR DESCRIPTION
The Okabe-Ito article URL was broken.

I converted this to a markdown-style link because the Wayback machine URL is long and ugly.  This will be nice in HTML-format help but makes it disappear from text-format help, which you might not want ...
