### PR TITLE
fix typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: colorblindr
 Type: Package
 Title: Simulate colorblindness in R figures
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c( 
     person("Claire D.", "McWhite", , "claire.mcwhite@utexas.edu", c("aut")),
     person("Claus O.", "Wilke", , "wilke@austin.utexas.edu", c("cre", "aut")))

--- a/R/cvd_grid.R
+++ b/R/cvd_grid.R
@@ -22,6 +22,6 @@ cvd_grid <- function(plot = last_plot(), severity = 1)
   p4 <- edit_colors(plot, des)
 
   cowplot::plot_grid(p1, p2, p3, p4, scale = 0.9, hjust = 0, vjust = 1,
-                     labels = c("Deutanomaly", "Protanomaly", "Tritanomaly", "Desaturated"),
+                     labels = c("Deuteranomaly", "Protanomaly", "Tritanomaly", "Desaturated"),
                      label_x = 0.01, label_y = 0.99, label_size = 12, label_fontface = "bold")
 }


### PR DESCRIPTION
One of the types of deficiency simulated by `colorblindr::cvd_grid()` is "Deutanomaly". I believe this should be spelled "Deuteranomaly". 

This small PR makes this tiny change. 

Closes https://github.com/clauswilke/colorblindr/issues/24